### PR TITLE
Include MediFlow.sln in dotnet restore and build commands

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Restore NuGet packages
         shell: powershell
         run: |
-          dotnet restore
+          dotnet restore MediFlow.sln
 
       - name: Begin SonarQube analysis
         env:
@@ -67,7 +67,7 @@ jobs:
       - name: Build the project
         shell: powershell
         run: |
-          dotnet build --no-restore --configuration Release
+          dotnet build MediFlow.sln --no-restore --configuration Release
           if ($LASTEXITCODE -ne 0) {
             Write-Host "Build failed, continuing with SonarQube analysis."
           }


### PR DESCRIPTION
Problem: Specify which project or solution file to use because this folder contains more than one project or solution file.
Solution: Include MediFlow.sln in dotnet restore and build commands