### PR TITLE
Configure Kestrel for HTTP/2 support without TLS for gRPC

### DIFF
--- a/src/Services/Inventory/Inventory.API/Program.cs
+++ b/src/Services/Inventory/Inventory.API/Program.cs
@@ -6,8 +6,23 @@ using Inventory.Application;
 using Inventory.Infrastructure;
 using Inventory.Infrastructure.Data.Extensions;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using System.Reflection;
+
 var builder = WebApplication.CreateBuilder(args);
+
+// Configure Kestrel to support HTTP/2 without TLS for gRPC
+builder.WebHost.ConfigureKestrel(options =>
+{
+    // Listen on port 8080 for HTTP requests
+    options.ListenAnyIP(
+        8080,
+        listenOptions =>
+        {
+            listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+        }
+    );
+});
 
 builder.Services
     .AddApplicationService(builder.Configuration)
@@ -28,11 +43,10 @@ app.UseApiServices();
 
 app.MapGrpcService<InventoryService>();
 
-app.UseHealthChecks("/health",
-    new HealthCheckOptions
-    {
-        ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-    });
+app.UseHealthChecks(
+    "/health",
+    new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse }
+);
 
 await app.UseMigrationAsync();
 

--- a/src/Services/Management/Management.API/Program.cs
+++ b/src/Services/Management/Management.API/Program.cs
@@ -16,123 +16,125 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 
-// gRPC Services
-builder.Services.AddGrpcClient<ApplicationUserProtoService.ApplicationUserProtoServiceClient>(options =>
-{
-    options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
-}).ConfigurePrimaryHttpMessageHandler(() =>
-{
-    var handler = new HttpClientHandler
+// gRPC Services - HumanResource related
+builder.Services
+    .AddGrpcClient<ApplicationUserProtoService.ApplicationUserProtoServiceClient>(options =>
     {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    };
-
-    return handler;
-});
-builder.Services.AddGrpcClient<RoleProtoService.RoleProtoServiceClient>(options =>
-{
-    options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
-}).ConfigurePrimaryHttpMessageHandler(() =>
-{
-    var handler = new HttpClientHandler
+        options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
+    })
+    .ConfigurePrimaryHttpMessageHandler(() =>
     {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    };
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        return handler;
+    });
 
-    return handler;
-});
-builder.Services.AddGrpcClient<DepartmentProtoService.DepartmentProtoServiceClient>(options =>
-{
-    options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
-}).ConfigurePrimaryHttpMessageHandler(() =>
-{
-    var handler = new HttpClientHandler
+builder.Services
+    .AddGrpcClient<RoleProtoService.RoleProtoServiceClient>(options =>
     {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    };
-
-    return handler;
-});
-builder.Services.AddGrpcClient<DepartmentTypeProtoService.DepartmentTypeProtoServiceClient>(options =>
-{
-    options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
-}).ConfigurePrimaryHttpMessageHandler(() =>
-{
-    var handler = new HttpClientHandler
+        options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
+    })
+    .ConfigurePrimaryHttpMessageHandler(() =>
     {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    };
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        return handler;
+    });
 
-    return handler;
-});
+builder.Services
+    .AddGrpcClient<DepartmentProtoService.DepartmentProtoServiceClient>(options =>
+    {
+        options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
+    })
+    .ConfigurePrimaryHttpMessageHandler(() =>
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        return handler;
+    });
 
+builder.Services
+    .AddGrpcClient<DepartmentTypeProtoService.DepartmentTypeProtoServiceClient>(options =>
+    {
+        options.Address = new Uri(builder.Configuration["GrpcSettings:HumanResourceUrl"]!);
+    })
+    .ConfigurePrimaryHttpMessageHandler(() =>
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        return handler;
+    });
+
+// gRPC Services - For Inventory and VaccinationReception (simpler configuration for production)
 builder.Services.AddGrpcClient<InventoryProtoService.InventoryProtoServiceClient>(options =>
 {
     options.Address = new Uri(builder.Configuration["GrpcSettings:InventoryUrl"]!);
-}).ConfigurePrimaryHttpMessageHandler(() =>
-{
-    var handler = new HttpClientHandler
-    {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    };
-
-    return handler;
 });
+
 builder.Services.AddGrpcClient<VaccinationReceptionProtoService.VaccinationReceptionProtoServiceClient>(options =>
 {
     options.Address = new Uri(builder.Configuration["GrpcSettings:VaccinationReceptionUrl"]!);
-}).ConfigurePrimaryHttpMessageHandler(() =>
-{
-    var handler = new HttpClientHandler
-    {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    };
-
-    return handler;
 });
 
 // Cross-Cutting Services
 builder.Services.AddSeqLogging(serviceName: Assembly.GetExecutingAssembly().GetName().Name!);
 
 builder.Services.AddMediatR(config =>
- {
-     config.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
-     config.AddOpenBehavior(typeof(ValidationBehavior<,>));
-     config.AddOpenBehavior(typeof(LoggingBehavior<,>));
- });
+{
+    config.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+    config.AddOpenBehavior(typeof(ValidationBehavior<,>));
+    config.AddOpenBehavior(typeof(LoggingBehavior<,>));
+});
 
-builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly(), includeInternalTypes: true);
+builder.Services.AddValidatorsFromAssembly(
+    Assembly.GetExecutingAssembly(),
+    includeInternalTypes: true
+);
 
 builder.Services.AddExceptionHandler<CustomExceptionHandler>();
 
 builder.Services.AddHealthChecks();
 
-builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-.AddJwtBearer(options =>
-{
-    options.SaveToken = true;
-    options.RequireHttpsMetadata = false;
-    options.TokenValidationParameters = new TokenValidationParameters
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
     {
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Secret"]!)),
-        ValidIssuer = builder.Configuration["Jwt:Issuer"],
-        ValidAudience = builder.Configuration["Jwt:Audience"],
-        ValidateLifetime = true,
-        ValidateIssuerSigningKey = true,
-        ClockSkew = TimeSpan.Zero
-    };
-});
+        options.SaveToken = true;
+        options.RequireHttpsMetadata = false;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Secret"]!)
+            ),
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ClockSkew = TimeSpan.Zero
+        };
+    });
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 app.UseExceptionHandler(options => { });
 
-app.UseHealthChecks("/health",
-    new HealthCheckOptions
-    {
-        ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-    });
+app.UseHealthChecks(
+    "/health",
+    new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse }
+);
 
 app.UseAuthentication();
 

--- a/src/Services/VaccinationReception/VaccinationReception.API/Program.cs
+++ b/src/Services/VaccinationReception/VaccinationReception.API/Program.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 using VaccinationReception.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using VaccinationReception.API.Services;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace VaccinationReception.API
 {
@@ -13,28 +14,43 @@ namespace VaccinationReception.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            // Configure Kestrel to support HTTP/2 without TLS for gRPC
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                // Listen on port 8080 for HTTP requests
+                options.ListenAnyIP(
+                    8080,
+                    listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                    }
+                );
+            });
+
             builder.Services
-            .AddApplicationService(builder.Configuration)
-            .AddInfrastructureServices(builder.Configuration)
-            .AddApiServices(builder.Configuration);
+                .AddApplicationService(builder.Configuration)
+                .AddInfrastructureServices(builder.Configuration)
+                .AddApiServices(builder.Configuration);
 
             builder.Services.AddFluentValidationAutoValidation();
 
             var httpHandler = new HttpClientHandler
             {
-                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                ServerCertificateCustomValidationCallback =
+                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
             };
-
 
             builder.Services
                 .AddHealthChecks()
                 .AddNpgSql(builder.Configuration.GetConnectionString("Database")!);
 
             TypeAdapterConfig.GlobalSettings.Scan(AppDomain.CurrentDomain.GetAssemblies());
-            TypeAdapterConfig.GlobalSettings.Default
-                .UseDestinationValue(member => member.SetterModifier == AccessModifier.None &&
-                                               member.Type.IsGenericType &&
-                                               member.Type.GetGenericTypeDefinition() == typeof(RepeatedField<>));
+            TypeAdapterConfig.GlobalSettings.Default.UseDestinationValue(
+                member =>
+                    member.SetterModifier == AccessModifier.None
+                    && member.Type.IsGenericType
+                    && member.Type.GetGenericTypeDefinition() == typeof(RepeatedField<>)
+            );
             builder.Services.AddSingleton<IRegister, MapsterConfig>();
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -64,11 +80,13 @@ namespace VaccinationReception.API
 
             app.UseApiServices();
 
-            app.UseHealthChecks("/health",
+            app.UseHealthChecks(
+                "/health",
                 new HealthCheckOptions
                 {
                     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-                });
+                }
+            );
 
             //await app.UseMigrationAsync();
 


### PR DESCRIPTION
Enable Kestrel to listen on port 8080 and support HTTP/2 without TLS for gRPC services across multiple applications. This change enhances the configuration for gRPC clients while maintaining existing service functionalities.