### PR TITLE
Bugfix: Remove AWS secret key reference from appointment deployment configuration

### DIFF
--- a/helm/templates/appointment/appointment-deployment.yaml
+++ b/helm/templates/appointment/appointment-deployment.yaml
@@ -36,10 +36,6 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-            valueFrom:
-              secretKeyRef:
-                name: aws-secret
-                key: SECRET_KEY
           envFrom:
             - configMapRef:
                 name: appointment-config


### PR DESCRIPTION
Eliminate the reference to the AWS secret key in the appointment deployment configuration to enhance security.